### PR TITLE
feat(platform): WCSS-4506 Cache header for redirects, clean up logs

### DIFF
--- a/RetourPlugin.php
+++ b/RetourPlugin.php
@@ -29,7 +29,7 @@ class RetourPlugin extends BasePlugin
         craft()->onException = function (\CExceptionEvent $event) {
             if ((($event->exception instanceof \CHttpException) && ($event->exception->statusCode == 404)) ||
                 (($event->exception->getPrevious() instanceof \CHttpException) && ($event->exception->getPrevious()->statusCode == 404))) {
-                RetourPlugin::log("A 404 exception occurred", LogLevel::Info, false);
+                RetourPlugin::log("A 404 exception occurred", LogLevel::Trace, false);
                 if (craft()->request->isSiteRequest() && !craft()->request->isLivePreview()) {
                     // See if we should redirect
                     $url = urldecode(craft()->request->getRequestUri());
@@ -38,7 +38,7 @@ class RetourPlugin extends BasePlugin
                         $url = UrlHelper::stripQueryString($url);
                     }
                     $noQueryUrl = UrlHelper::stripQueryString($url);
-                    RetourPlugin::log("404 URL: " . $url, LogLevel::Info, false);
+                    RetourPlugin::log("404 URL: " . $url, LogLevel::Trace, false);
 
                     // Redirect if we find a match, otherwise let Craft handle it
                     $redirect = craft()->retour->findRedirectMatch($url);
@@ -46,7 +46,8 @@ class RetourPlugin extends BasePlugin
                     if (isset($redirect)) {
                         craft()->retour->incrementStatistics($url, true);
                         $event->handled = true;
-                        RetourPlugin::log("Redirecting " . $url . " to " . $redirect['redirectDestUrl'], LogLevel::Info, false);
+                        RetourPlugin::log("Redirecting " . $url . " to " . $redirect['redirectDestUrl'], LogLevel::Trace, false);
+                        header('Cache-Control: max-age=3600');
                         craft()->request->redirect($redirect['redirectDestUrl'], true, $redirect['redirectHttpCode']);
                     } else {
                         // Now try it without the query string, too, otherwise let Craft handle it
@@ -55,7 +56,8 @@ class RetourPlugin extends BasePlugin
                         if (isset($redirect)) {
                             craft()->retour->incrementStatistics($url, true);
                             $event->handled = true;
-                            RetourPlugin::log("Redirecting " . $url . " to " . $redirect['redirectDestUrl'], LogLevel::Info, false);
+                            RetourPlugin::log("Redirecting " . $url . " to " . $redirect['redirectDestUrl'], LogLevel::Trace, false);
+                            header('Cache-Control: max-age=3600');
                             craft()->request->redirect($redirect['redirectDestUrl'], true, $redirect['redirectHttpCode']);
                         } else {
                             craft()->retour->incrementStatistics($url, false);
@@ -77,7 +79,7 @@ class RetourPlugin extends BasePlugin
                         $field = craft()->fields->getFieldById($fieldLayout->fieldId);
                         if ($field->type == "Retour") {
                             craft()->elements->saveElement($element);
-                            RetourPlugin::log("Resaved moved structure element", LogLevel::Info, false);
+                            RetourPlugin::log("Resaved moved structure element", LogLevel::Trace, false);
                             break;
                         }
                     }
@@ -180,7 +182,7 @@ class RetourPlugin extends BasePlugin
      */
     public function getVersion()
     {
-        return '1.0.24';
+        return '1.0.25';
     }
 
     /**

--- a/services/RetourService.php
+++ b/services/RetourService.php
@@ -90,13 +90,13 @@ class RetourService extends BaseApplicationComponent
         $urlLocale = $url . $this->getLocale();
         $urlAll = $url . "all";
 
+        // Check the cache for each url ({url}/{locale} {url}/all and {url})
         foreach ([$urlLocale, $urlAll, $url] as $url) {
             $redirect = $this->getRedirectFromCache($url);
             if ($redirect) {
                 $error = $this->incrementRedirectHitCount($redirect);
-                $this->saveRedirectToCache($url, $redirect);
                 RetourPlugin::log("[cached] " . $redirect['redirectMatchType'] . " result: " . print_r($error, true),
-                    LogLevel::Info, false);
+                    LogLevel::Trace, false);
 
                 return $redirect;
             }
@@ -117,10 +117,11 @@ class RetourService extends BaseApplicationComponent
 
         if ($result) {
             if ($result['locale'] == 'all' && !$this->checkCachedRedirectsForEachLocale($url)) {
-                //There's a chance that it found an "all" but
-                //there's also at least one specific match still lurking...
-                //cache those as well, and if it turns out it's actually the
-                //redirect we wanted, use it instead.
+                // There's a chance that it found an "all" but
+                // there's also at least one specific match still lurking...
+                // cache those as well, and if it turns out it's actually the
+                // redirect we wanted, use it instead.
+                // e.g. you visit /showcase/ so /showcase/all/ matches but /showcase/en_au exists
                 $query = craft()->db->createCommand()
                     ->select('*')
                     ->from('retour_static_redirects')
@@ -133,13 +134,13 @@ class RetourService extends BaseApplicationComponent
                     //Again, this can happen if a match was made prematurely
                     if ($specificRedirect['locale'] == $this->getLocale()) {
                         $error = $this->incrementRedirectHitCount($specificRedirect);
-                        RetourPlugin::log($specificRedirect['redirectMatchType'] . " result: " . print_r($error, true), LogLevel::Info, false);
+                        RetourPlugin::log($specificRedirect['redirectMatchType'] . " result: " . print_r($error, true), LogLevel::Trace, false);
                         return $specificRedirect;
                     }
                 }
             }
             $error = $this->incrementRedirectHitCount($result);
-            RetourPlugin::log($result['redirectMatchType'] . " result: " . print_r($error, true), LogLevel::Info, false);
+            RetourPlugin::log($result['redirectMatchType'] . " result: " . print_r($error, true), LogLevel::Trace, false);
 
             return $result;
         }
@@ -172,7 +173,6 @@ class RetourService extends BaseApplicationComponent
     {
         $cacheKey = "retour_cache_" . md5($url);
         $result = craft()->cache->get($cacheKey);
-        RetourPlugin::log("Cached Redirect hit: " . print_r($result, true), LogLevel::Info, false);
 
         return $result;
     }
@@ -207,7 +207,7 @@ class RetourService extends BaseApplicationComponent
     {
         $cacheKey = "retour_cache_" . md5($url);
         $error = craft()->cache->set($cacheKey, $redirect, 0);
-        RetourPlugin::log("Cached Redirect saved: " . print_r($error, true), LogLevel::Info, false);
+        RetourPlugin::log("Cached Redirect saved: " . print_r($error, true), LogLevel::Trace, false);
     }
 
     /**
@@ -294,7 +294,7 @@ class RetourService extends BaseApplicationComponent
                             $result = call_user_func_array(array($plugin, "retourMatch"), $args);
                             if ($result) {
                                 $error = $this->incrementRedirectHitCount($redirect);
-                                RetourPlugin::log($redirectMatchType . " result: " . print_r($error, true), LogLevel::Info, false);
+                                RetourPlugin::log($redirectMatchType . " result: " . print_r($error, true), LogLevel::Trace, false);
                                 $this->saveRedirectToCache($url, $redirect);
 
                                 return $redirect;
@@ -351,14 +351,14 @@ class RetourService extends BaseApplicationComponent
                     'id' => $id,
                 ));
 
-                RetourPlugin::log("Deleted Redirected: " . $id, LogLevel::Info, false);
+                RetourPlugin::log("Deleted Redirect: " . $id, LogLevel::Trace, false);
                 $error = craft()->cache->flush();
-                RetourPlugin::log("Cache flushed: " . print_r($error, true), LogLevel::Info, false);
+                RetourPlugin::log("Cache flushed: " . print_r($error, true), LogLevel::Trace, false);
                 $error = -1;
             } else {
                 if ($record->save()) {
                     $error = craft()->cache->flush();
-                    RetourPlugin::log("Cache flushed: " . print_r($error, true), LogLevel::Info, false);
+                    RetourPlugin::log("Cache flushed: " . print_r($error, true), LogLevel::Trace, false);
                     craft()->userSession->setNotice(Craft::t('Retour Redirect saved.'));
                     $error = "";
 
@@ -372,7 +372,7 @@ class RetourService extends BaseApplicationComponent
                     }
                 } else {
                     $error = $record->getErrors();
-                    RetourPlugin::log(print_r($error, true), LogLevel::Info, false);
+                    RetourPlugin::log(print_r($error, true), LogLevel::Trace, false);
                     craft()->userSession->setError(Craft::t('Couldn’t save Retour Redirect.'));
                 }
             }
@@ -482,7 +482,7 @@ class RetourService extends BaseApplicationComponent
               ) foo
             )
         ")->execute();
-            RetourPlugin::log("Trimmed " . $affectedRows . " from retour_stats table", LogLevel::Info, false);
+            RetourPlugin::log("Trimmed " . $affectedRows . " from retour_stats table", LogLevel::Trace, false);
         }
     }
 
@@ -511,7 +511,7 @@ class RetourService extends BaseApplicationComponent
             } else {
                 $error = $this->createRedirect($redirectsModel);
             }
-            RetourPlugin::log(print_r($error, true), LogLevel::Info, false);
+            RetourPlugin::log(print_r($error, true), LogLevel::Trace, false);
         }
     }
 
@@ -540,7 +540,7 @@ class RetourService extends BaseApplicationComponent
                 $result->setAttributes($redirectsModel->getAttributes(), false);
                 $result->save();
                 $error = $result->getErrors();
-                RetourPlugin::log(print_r($error, true), LogLevel::Info, false);
+                RetourPlugin::log(print_r($error, true), LogLevel::Trace, false);
             }
         }
     }


### PR DESCRIPTION
[WCSS-4506](https://jira.bigcommerce.com/browse/WCSS-4506)
## What
1. Add cache headers for 301 redirects
2. Change most logs over to trace level

## Why
1. CDN will cache 301s reducing server load
2. These logs are really garbaging up the server/Kibana

## Test
1. Copy files over manually or update `composer.json` in bc-craft to point to this hash
2. visit https://bc.craft.local/showcase/homeware/ with the network tab open
3. Make sure `Cache-Control max-age` is set as a response header
4. Check `retour.log` to see if logs are coming in as trace instead of info if you have trace turned on

## Screenshots
<img width="453" alt="Screen Shot 2021-07-12 at 2 59 20 PM" src="https://user-images.githubusercontent.com/5215365/125348447-128b4b80-e311-11eb-8782-e99e9aaa991f.png">
<img width="843" alt="Screen Shot 2021-07-12 at 2 59 40 PM" src="https://user-images.githubusercontent.com/5215365/125348448-1323e200-e311-11eb-93cc-b8f084b2e6db.png">
